### PR TITLE
Fixes 'signmessage' produces invalid signature

### DIFF
--- a/apiv1/wallet/address/main.go
+++ b/apiv1/wallet/address/main.go
@@ -161,7 +161,7 @@ func (r *rpc) signmessage(in *rpc_pb.SignMessageRequest) (*rpc_pb.SignMessageRes
 
 	var buf bytes.Buffer
 	wire.WriteVarString(&buf, 0, "Bitcoin Signed Message:\n")
-	buf.Write(msg)
+	wire.WriteVarBytes(&buf, 0, msg)
 	messageHash := chainhash.DoubleHashB(buf.Bytes())
 	sigbytes, err := btcec.SignCompact(btcec.S256(), privKey,
 		messageHash, true)


### PR DESCRIPTION
The signature produced by `wallet/address/signmessage` is invalid.

```
./bin/pldctl wallet/address/signmessage --msg='Hello, world!' --address=pkt1q6sj0mchq7ltwm8c9tpm2wteqmeldr2ye5lcr60
{
	"signature": "H7MgcJrl8y/nrOuOefHx7oMVp7wCWxbt+VmtNuVyR2P0ATXhfvH+4RUFVPO5hlpVpzfPLMZ6Rmovu/65fceXXmQ="
}
```
After this patch:

```
./bin/pldctl wallet/address/signmessage --msg='Hello, world!' --address=pkt1q6sj0mchq7ltwm8c9tpm2wteqmeldr2ye5lcr60
{
	"signature":  "IH73zLeFgqeYZL0zSnS0bMbumiwYaiY7521KqrG4rjDKENMhPGJljlTAM86EPqeI4+CnXn7xoHXSMim/OsBPLUo="
}
```

Signatures can be tested here: https://www.verifybitcoinmessage.com/
